### PR TITLE
se agrego la propiedad gap:0.5rem al menu responsive para que el hove…

### DIFF
--- a/client/src/components/nav/Nav.module.css
+++ b/client/src/components/nav/Nav.module.css
@@ -128,6 +128,7 @@
     flex-direction: column;
     justify-content: start;
     padding-top: 5%;
+    gap:0.5rem;
   }
   .ocultarmenu {
     position: absolute;


### PR DESCRIPTION
se agrego la propiedad gap:0.5rem al menu responsive de client para que el hover no chocara con los botones adyacentes